### PR TITLE
feat: implement calendar design from Figma specs

### DIFF
--- a/src/app/api/diaries/messages/route.ts
+++ b/src/app/api/diaries/messages/route.ts
@@ -1,6 +1,37 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseServer } from '@/lib/supabase/server';
 
+export async function GET(req: NextRequest) {
+  const supabase = await supabaseServer();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'unauth' }, { status: 401 });
+
+  const date = req.nextUrl.searchParams.get('date');
+  if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return NextResponse.json({ error: 'missing or invalid date param' }, { status: 400 });
+  }
+
+  const { data, error } = await supabase
+    .from('diary_messages')
+    .select(`
+      id,
+      role,
+      text,
+      audio_url,
+      created_at,
+      diaries!inner(date, user_id)
+    `)
+    .eq('diaries.date', date)
+    .eq('diaries.user_id', user.id)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json(data || []);
+}
+
 export async function POST(req: NextRequest) {
   const { diaryId, role, text, audioUrl, triggerAI = false } = await req.json();
 

--- a/src/app/calendar/CalendarClient.tsx
+++ b/src/app/calendar/CalendarClient.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import React, { useState } from 'react'
+import { ArrowLeft } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { format } from 'date-fns'
+import Calendar from '@/app/components/Calendar'
+import ItemListSection from '@/app/components/ItemListSection'
+
+export default function CalendarClient() {
+  const router = useRouter()
+  const [selectedDate, setSelectedDate] = useState<Date>(new Date())
+
+  const handleDateSelect = (date: Date) => {
+    setSelectedDate(date)
+  }
+
+  const handleBackClick = () => {
+    router.push('/')
+  }
+
+  return (
+    <div className="bg-[#ecedf3] flex flex-row justify-center w-full min-h-screen">
+      <div className="bg-[#ecedf3] w-full max-w-[390px] relative flex flex-col">
+        <header className="flex items-center justify-center pt-[60px] px-6 relative">
+          <button 
+            onClick={handleBackClick}
+            className="absolute left-6"
+          >
+            <ArrowLeft className="w-7 h-7 text-[#212121]" />
+          </button>
+          <h1 className="font-['Bakbak_One-Regular'] font-normal text-[#212121] text-[28px] text-center tracking-[0]">
+            review
+          </h1>
+        </header>
+
+        <main className="flex flex-col flex-1 w-full relative">
+          {/* Calendar Section */}
+          <div className="w-full px-2">
+            <Calendar 
+              selectedDate={selectedDate} 
+              onDateSelect={handleDateSelect}
+            />
+          </div>
+
+          {/* Item List Section */}
+          <div className="w-full px-4 pb-6">
+            <ItemListSection 
+              selectedDate={format(selectedDate, 'yyyy-MM-dd')}
+            />
+          </div>
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,7 +1,6 @@
 import { redirect } from 'next/navigation'
 import { supabaseServer } from "@/lib/supabase/server";
-import DiaryHeatmap from '@/app/components/DiaryHeatmap'
-import Link from 'next/link'
+import CalendarClient from './CalendarClient'
 
 export default async function Calendar() {
   const supabase = await supabaseServer()
@@ -9,19 +8,5 @@ export default async function Calendar() {
 
   if (!user) redirect('/login')
 
-  const today = new Date()
-  return (
-    <main className="p-4">
-      <div className="flex items-center justify-between mb-4">
-        <h1 className="text-xl font-bold">My Gratitude Calendar</h1>
-        <Link 
-          href="/"
-          className="px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-lg transition-colors"
-        >
-          AIと話す
-        </Link>
-      </div>
-      <DiaryHeatmap year={today.getFullYear()} month={today.getMonth() + 1} />
-    </main>
-  )
+  return <CalendarClient />
 }

--- a/src/app/components/Calendar.tsx
+++ b/src/app/components/Calendar.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import React, { useState, useMemo } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import useSWR from 'swr'
+import { format, eachDayOfInterval, startOfMonth, endOfMonth, startOfWeek, endOfWeek, isSameMonth, isSameDay } from 'date-fns'
+
+interface DiaryData {
+  date: string
+  count?: number
+  mood_emoji?: string
+}
+
+interface CalendarProps {
+  selectedDate?: Date
+  onDateSelect?: (date: Date) => void
+}
+
+export default function Calendar({ selectedDate, onDateSelect }: CalendarProps) {
+  const router = useRouter()
+  const [currentDate, setCurrentDate] = useState(selectedDate || new Date())
+  
+  const year = currentDate.getFullYear()
+  const month = currentDate.getMonth() + 1
+  const ym = `${year}-${String(month).padStart(2, '0')}`
+
+  const fetcher = (url: string): Promise<DiaryData[]> =>
+    fetch(url).then((r) => r.json() as Promise<DiaryData[]>)
+
+  const { data } = useSWR<DiaryData[]>(`/api/diaries?month=${ym}`, fetcher)
+
+  const { calendarDays, diaryMap } = useMemo(() => {
+    const monthStart = startOfMonth(currentDate)
+    const monthEnd = endOfMonth(currentDate)
+    const calendarStart = startOfWeek(monthStart, { weekStartsOn: 0 }) // Sunday start
+    const calendarEnd = endOfWeek(monthEnd, { weekStartsOn: 0 })
+
+    const days = eachDayOfInterval({
+      start: calendarStart,
+      end: calendarEnd,
+    })
+
+    const dMap: Record<string, DiaryData> = Object.fromEntries(
+      (data ?? []).map((d) => [d.date, d])
+    )
+
+    return { calendarDays: days, diaryMap: dMap }
+  }, [currentDate, data])
+
+  const daysOfWeek = ['日', '月', '火', '水', '木', '金', '土']
+
+  const navigateMonth = (direction: 'prev' | 'next') => {
+    const newDate = new Date(currentDate)
+    if (direction === 'prev') {
+      newDate.setMonth(newDate.getMonth() - 1)
+    } else {
+      newDate.setMonth(newDate.getMonth() + 1)
+    }
+    setCurrentDate(newDate)
+  }
+
+  const handleDateClick = (date: Date) => {
+    if (onDateSelect) {
+      onDateSelect(date)
+    }
+    const dateStr = format(date, 'yyyy-MM-dd')
+    router.push(`/diary/${dateStr}`)
+  }
+
+  // Split days into weeks
+  const weeks = []
+  for (let i = 0; i < calendarDays.length; i += 7) {
+    weeks.push(calendarDays.slice(i, i + 7))
+  }
+
+  return (
+    <div className="flex flex-col w-full items-center gap-6 bg-[#ecedf3] p-4">
+      {/* Month navigation header */}
+      <div className="flex items-center justify-between px-3 py-0 w-full max-w-sm">
+        <button 
+          onClick={() => navigateMonth('prev')}
+          className="flex items-center justify-center w-6 h-6"
+        >
+          <ChevronLeft className="w-6 h-6 text-gray-800" />
+        </button>
+
+        <h2 className="font-['Euclid_Circular_B-Medium'] font-medium text-[#212121] text-[21px]">
+          {format(currentDate, 'yyyy/MM')}
+        </h2>
+
+        <button 
+          onClick={() => navigateMonth('next')}
+          className="flex items-center justify-center w-6 h-6"
+        >
+          <ChevronRight className="w-6 h-6 text-gray-800" />
+        </button>
+      </div>
+
+      {/* Calendar grid */}
+      <div className="flex flex-col items-start gap-1 w-full max-w-sm">
+        {/* Days of week header */}
+        <div className="flex items-center justify-between w-full">
+          {daysOfWeek.map((day, index) => (
+            <div
+              key={`day-${index}`}
+              className="w-12 font-['Euclid_Circular_B-Medium'] font-medium text-[#212121] text-[13px] text-center"
+            >
+              {day}
+            </div>
+          ))}
+        </div>
+
+        {/* Calendar weeks */}
+        {weeks.map((week, weekIndex) => (
+          <div
+            key={`week-${weekIndex}`}
+            className="flex items-center justify-between w-full"
+          >
+            {week.map((date, dayIndex) => {
+              const dateStr = format(date, 'yyyy-MM-dd')
+              const isCurrentMonth = isSameMonth(date, currentDate)
+              const isSelected = selectedDate && isSameDay(date, selectedDate)
+              const isToday = isSameDay(date, new Date())
+              const hasDiary = diaryMap[dateStr]
+              const dayNumber = date.getDate()
+
+              // Handle days outside current month
+              if (!isCurrentMonth) {
+                return (
+                  <div key={`empty-${weekIndex}-${dayIndex}`} className="w-[50px] h-12">
+                    <div className="w-12 h-12 font-normal text-transparent text-[13px] text-center">
+                      0
+                    </div>
+                  </div>
+                )
+              }
+
+              // Handle current day (today) without background
+              if (isToday && !isSelected) {
+                return (
+                  <button
+                    key={`day-${dayNumber}`}
+                    onClick={() => handleDateClick(date)}
+                    className="w-12 h-12 font-['Euclid_Circular_B-SemiBold'] font-semibold text-[#212121] text-[15px] text-center flex items-center justify-center hover:bg-gray-200 rounded-full transition-colors"
+                  >
+                    {dayNumber}
+                  </button>
+                )
+              }
+
+              // Handle days with diary entries or selected state
+              return (
+                <div key={`day-${dayNumber}`} className="relative w-[50px] h-12">
+                  <button
+                    onClick={() => handleDateClick(date)}
+                    className="relative w-12 h-12 hover:opacity-80 transition-opacity"
+                  >
+                    <div
+                      className={`absolute w-[30px] h-[30px] top-[9px] left-[9px] 
+                        ${hasDiary ? 'bg-[#ec6a52]' : 'bg-[#21212157]'} 
+                        ${isSelected ? 'rounded-[7px]' : 'rounded-[39px]'}`}
+                    />
+                    <div className="absolute top-0 left-0 font-['Euclid_Circular_B-Regular'] font-normal text-white text-[15px] w-12 h-12 text-center flex items-center justify-center">
+                      {dayNumber}
+                    </div>
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/app/components/ItemListSection.tsx
+++ b/src/app/components/ItemListSection.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { Card, CardContent } from "@/components/ui/card"
+import { ChevronRight, Play } from "lucide-react"
+import React from "react"
+import { useRouter } from "next/navigation"
+import useSWR from "swr"
+
+interface DiaryMessage {
+  id: number
+  role: 'user' | 'ai'
+  text: string
+  audio_url?: string
+  created_at: string
+}
+
+interface ItemListSectionProps {
+  selectedDate?: string // Format: YYYY-MM-DD
+}
+
+export default function ItemListSection({ selectedDate }: ItemListSectionProps) {
+  const router = useRouter()
+
+  const fetcher = (url: string): Promise<DiaryMessage[]> =>
+    fetch(url).then((r) => r.json() as Promise<DiaryMessage[]>)
+
+  const { data: messages } = useSWR<DiaryMessage[]>(
+    selectedDate ? `/api/diaries/messages?date=${selectedDate}` : null,
+    fetcher
+  )
+
+  if (!selectedDate || !messages?.length) {
+    return (
+      <section className="flex flex-col w-full items-center justify-center gap-4 py-8">
+        <p className="text-[#212121] text-center font-['Euclid_Circular_B-Regular']">
+          {selectedDate ? '今日はまだ日記がありません' : '日付を選択してください'}
+        </p>
+      </section>
+    )
+  }
+
+  const handleItemClick = (message: DiaryMessage) => {
+    // Navigate to diary detail page or play audio
+    if (selectedDate) {
+      router.push(`/diary/${selectedDate}`)
+    }
+  }
+
+  const handlePlayAudio = (audioUrl: string, e: React.MouseEvent) => {
+    e.stopPropagation()
+    // TODO: Implement audio playback
+    console.log('Play audio:', audioUrl)
+  }
+
+  return (
+    <section className="flex flex-col w-full items-start gap-3">
+      {messages.map((message, index) => {
+        const isUser = message.role === 'user'
+        const title = isUser ? `あなたの記録 ${index + 1}` : `AIの返答 ${index + 1}`
+        const hasAudio = Boolean(message.audio_url)
+        
+        return (
+          <Card
+            key={message.id}
+            className="w-full shadow-[0px_12px_20px_#0000000d] rounded-[17px] border-0"
+          >
+            <CardContent className="flex items-center justify-between gap-6 p-4">
+              <div className="flex items-start gap-4 flex-1">
+                <div className="flex-shrink-0">
+                  <div className="relative w-12 h-12">
+                    <div className="absolute w-12 h-12 top-0 left-0 rounded-3xl border-[3px] border-solid border-[#21212126] rotate-[-90deg]" />
+                    <div className="absolute w-[42px] h-[42px] top-[3px] left-[3px] bg-white rounded-[21px] flex items-center justify-center">
+                      {hasAudio ? (
+                        <button
+                          onClick={(e) => message.audio_url && handlePlayAudio(message.audio_url, e)}
+                          className="flex items-center justify-center"
+                        >
+                          <Play
+                            size={13}
+                            className="text-[#ec6a52] fill-[#ec6a52]"
+                          />
+                        </button>
+                      ) : (
+                        <div className="flex gap-0.5">
+                          <div className="w-1 h-3.5 rounded-[1px] bg-[#ec6a52]" />
+                          <div className="w-1 h-3.5 rounded-[1px] bg-[#ec6a52]" />
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex flex-col items-start gap-1.5 flex-1">
+                  <div className="w-full">
+                    <h3 className="font-semibold text-[17px] text-[#212121] mt-[-1px] font-['Euclid_Circular_B-SemiBold']">
+                      {title}
+                    </h3>
+                    <p className="text-[13px] text-[#212121] mt-[-1px] font-['Euclid_Circular_B-Regular'] line-clamp-3">
+                      {message.text}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <button onClick={() => handleItemClick(message)}>
+                <ChevronRight size={16} className="text-gray-400" />
+              </button>
+            </CardContent>
+          </Card>
+        )
+      })}
+    </section>
+  )
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -63,6 +63,13 @@
   .color-level-4 {
     fill: #196127;
   }
+
+  .line-clamp-3 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+  }
 }
 
 :root {


### PR DESCRIPTION
Issue #35: カレンダー画面デザイン実装

Implemented a completely new calendar interface based on the provided Figma export designs.

## Changes
- Replaced react-calendar-heatmap with custom calendar component
- Added Calendar component with month navigation and date selection
- Added ItemListSection for displaying diary entries
- Added CalendarClient for responsive mobile-first layout
- Added API endpoint for fetching diary messages by date
- Implemented Figma design specifications with proper colors and fonts
- Added responsive design support (max-width 390px)

## Design Features
- Background: `#ecedf3`
- Selected dates: rounded squares
- Non-selected dates: circles
- Diary entries: orange (`#ec6a52`)
- No entries: gray (`#212121` with transparency)
- Mobile-first responsive design
- Japanese day-of-week labels

Generated with [Claude Code](https://claude.ai/code)