### PR TITLE
feat: implement mobile AI chat interface based on Figma design

### DIFF
--- a/public/terase-bot-placeholder.svg
+++ b/public/terase-bot-placeholder.svg
@@ -1,0 +1,97 @@
+<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Outer orbit ring -->
+  <circle cx="100" cy="100" r="90" stroke="#c7c7cc" stroke-width="2" fill="none" opacity="0.3">
+    <animateTransform
+      attributeName="transform"
+      attributeType="XML"
+      type="rotate"
+      from="0 100 100"
+      to="360 100 100"
+      dur="10s"
+      repeatCount="indefinite"/>
+  </circle>
+  
+  <!-- Middle orbit ring -->
+  <circle cx="100" cy="100" r="70" stroke="#8e8e93" stroke-width="2" fill="none" opacity="0.5">
+    <animateTransform
+      attributeName="transform"
+      attributeType="XML"
+      type="rotate"
+      from="0 100 100"
+      to="-360 100 100"
+      dur="7s"
+      repeatCount="indefinite"/>
+  </circle>
+  
+  <!-- Inner orbit ring -->
+  <circle cx="100" cy="100" r="50" stroke="#007aff" stroke-width="2" fill="none" opacity="0.7">
+    <animateTransform
+      attributeName="transform"
+      attributeType="XML"
+      type="rotate"
+      from="0 100 100"
+      to="360 100 100"
+      dur="5s"
+      repeatCount="indefinite"/>
+  </circle>
+  
+  <!-- Central sphere with gradient -->
+  <defs>
+    <radialGradient id="sphereGradient" cx="0.3" cy="0.3" r="0.7">
+      <stop offset="0%" style="stop-color:#ffffff;stop-opacity:0.8" />
+      <stop offset="50%" style="stop-color:#007aff;stop-opacity:0.9" />
+      <stop offset="100%" style="stop-color:#0056d6;stop-opacity:1" />
+    </radialGradient>
+  </defs>
+  
+  <!-- Central core -->
+  <circle cx="100" cy="100" r="25" fill="url(#sphereGradient)">
+    <animate attributeName="r" values="25;30;25" dur="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;1;0.8" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  
+  <!-- Orbiting particles -->
+  <circle cx="170" cy="100" r="3" fill="#ff3b30" opacity="0.7">
+    <animateTransform
+      attributeName="transform"
+      attributeType="XML"
+      type="rotate"
+      from="0 100 100"
+      to="360 100 100"
+      dur="10s"
+      repeatCount="indefinite"/>
+  </circle>
+  
+  <circle cx="30" cy="100" r="3" fill="#34c759" opacity="0.7">
+    <animateTransform
+      attributeName="transform"
+      attributeType="XML"
+      type="rotate"
+      from="180 100 100"
+      to="540 100 100"
+      dur="10s"
+      repeatCount="indefinite"/>
+  </circle>
+  
+  <circle cx="100" cy="30" r="3" fill="#ff9500" opacity="0.7">
+    <animateTransform
+      attributeName="transform"
+      attributeType="XML"
+      type="rotate"
+      from="270 100 100"
+      to="630 100 100"
+      dur="10s"
+      repeatCount="indefinite"/>
+  </circle>
+  
+  <circle cx="100" cy="170" r="3" fill="#af52de" opacity="0.7">
+    <animateTransform
+      attributeName="transform"
+      attributeType="XML"
+      type="rotate"
+      from="90 100 100"
+      to="450 100 100"
+      dur="10s"
+      repeatCount="indefinite"/>
+  </circle>
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation'
 import { supabaseServer } from "@/lib/supabase/server";
 import ConversationInterface from '@/components/ConversationInterface'
+import MobileConversationInterface from '@/components/MobileConversationInterface'
 
 export default async function Home() {
   const supabase = await supabaseServer()
@@ -10,7 +11,15 @@ export default async function Home() {
 
   return (
     <main className="relative h-screen">
-      <ConversationInterface />
+      {/* Mobile interface for small screens */}
+      <div className="block md:hidden">
+        <MobileConversationInterface />
+      </div>
+      
+      {/* Desktop interface for larger screens */}
+      <div className="hidden md:block">
+        <ConversationInterface />
+      </div>
     </main>
   )
 }

--- a/src/components/MobileConversationInterface.tsx
+++ b/src/components/MobileConversationInterface.tsx
@@ -1,0 +1,250 @@
+'use client'
+import React from 'react';
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Calendar, Mic } from "lucide-react";
+import Link from 'next/link';
+import { useRecorder } from '@/components/hooks/useRecorder';
+import { useConversation } from '@/components/hooks/useConversation';
+import { useTodayDiary } from '@/components/hooks/useTodayDiary';
+import { useConversationStore } from '@/stores/useConversationStore';
+
+export default function MobileConversationInterface() {
+  const { recording, start, stop } = useRecorder();
+  const { diaryId } = useTodayDiary();
+  const { state, processConversation, startListening, stopConversation } = useConversation(diaryId || undefined);
+  const { 
+    messages, 
+    liveTranscript, 
+    setRecording, 
+    setLiveTranscript, 
+    error, 
+    setError 
+  } = useConversationStore();
+
+  // 録音状態をストアと同期
+  React.useEffect(() => {
+    setRecording(recording);
+  }, [recording, setRecording]);
+
+  // メイン録音ボタンの処理
+  const handleToggleRecording = async () => {
+    try {
+      if (recording) {
+        // 録音停止 → 処理開始
+        const audioBlob = await stop();
+        await processConversation(audioBlob);
+      } else {
+        // 録音開始
+        startListening();
+        setLiveTranscript('録音中...');
+        await start();
+      }
+    } catch (error) {
+      console.error('Recording error:', error);
+      setError('録音に失敗しました');
+      stopConversation();
+    }
+  };
+
+  // グリーティングテキストのデータ（非録音時）
+  const greetingLines = [
+    { text: "こんにちはteraseです。", opacity: "text-[#2121211a]" },
+    { text: "今日はどんな一日でしたか？", opacity: "text-[#21212140]" },
+    { text: "一緒に振り返りましょう。", opacity: "text-[#212121]" },
+  ];
+
+  // 会話データ（録音中時）
+  const getConversationData = () => {
+    const conversationMessages = [];
+    
+    // 最新のメッセージから最大4つを取得
+    if (messages.length > 0) {
+      const recentMessages = messages.slice(-4);
+      recentMessages.forEach((msg, index) => {
+        const opacity = index === recentMessages.length - 1 ? 'opacity-100' : 
+                       index === recentMessages.length - 2 ? 'opacity-50' : 
+                       index === recentMessages.length - 3 ? 'opacity-25' : 'opacity-10';
+        
+        conversationMessages.push({
+          text: msg.content.length > 20 ? msg.content.substring(0, 20) + '...' : msg.content,
+          opacity,
+          speaker: msg.speaker
+        });
+      });
+    }
+
+    // ライブ文字起こしがある場合は追加
+    if (liveTranscript && liveTranscript !== '録音中...') {
+      conversationMessages.push({
+        text: liveTranscript.length > 20 ? liveTranscript.substring(0, 20) + '...' : liveTranscript,
+        opacity: 'opacity-100',
+        speaker: 'user'
+      });
+    }
+
+    // デフォルトメッセージで埋める（会話がない場合）
+    if (conversationMessages.length === 0) {
+      return [
+        { text: "今日はどんな一日でしたか？", opacity: "opacity-25", speaker: 'ai' },
+        { text: "一緒に振り返りましょう。", opacity: "opacity-50", speaker: 'ai' },
+        { text: "よろしくお願いします。", opacity: "opacity-75", speaker: 'ai' },
+        { text: "今日は友だちと遊びました。", opacity: "opacity-100", speaker: 'user' },
+      ];
+    }
+
+    return conversationMessages.slice(-4); // 最大4つまで
+  };
+
+  const conversationData = getConversationData();
+  const isRecordingOrActive = recording || state !== 'idle';
+  const isProcessing = ['transcribing', 'thinking'].includes(state);
+
+  return (
+    <main className="bg-[#ecedf3] flex flex-row justify-center w-full min-h-screen">
+      <div className="bg-[#ecedf3] w-full max-w-[390px] min-h-screen relative">
+        {/* App header */}
+        <header className="absolute top-[53px] left-0 right-0 flex justify-between items-center px-9">
+          <div className="flex-1"></div> {/* Spacer */}
+          <h1 className="font-bold text-[#212121] text-[28px] text-center tracking-wider">
+            terase
+          </h1>
+          <div className="flex-1 flex justify-end">
+            <Link href="/calendar">
+              <Calendar className="w-7 h-7 text-[#212121] hover:text-[#212121]/80 transition-colors" />
+            </Link>
+          </div>
+        </header>
+
+        {/* Main image/graphic */}
+        <div className="absolute w-[200px] h-[200px] top-56 left-1/2 transform -translate-x-1/2">
+          <div className="relative w-[200px] h-[200px]">
+            <img
+              className="w-full h-full object-contain"
+              alt="terase AI companion sphere"
+              src="/terase-bot-placeholder.svg"
+            />
+          </div>
+        </div>
+
+        {/* Conversation content */}
+        {!isRecordingOrActive ? (
+          // 非録音時: グリーティングテキスト
+          <Card className="absolute w-[306px] top-[447px] left-9 border-none shadow-none bg-transparent">
+            <CardContent className="p-0">
+              <p className="font-bold text-[23px] tracking-[0] leading-[34px]">
+                {greetingLines.map((line, index) => (
+                  <React.Fragment key={index}>
+                    <span className={line.opacity}>{line.text}</span>
+                    {index < greetingLines.length - 1 && <br />}
+                  </React.Fragment>
+                ))}
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          // 録音中または処理中: 会話履歴
+          <>
+            {/* AIメッセージ（左側） */}
+            <div className="absolute w-[306px] top-[447px] left-9 space-y-1">
+              {conversationData
+                .filter(item => item.speaker === 'ai')
+                .slice(0, 2)
+                .map((item, index) => (
+                  <p
+                    key={index}
+                    className={`text-[#212121] ${item.opacity} text-[23px] leading-[34px] font-bold tracking-[0]`}
+                  >
+                    {item.text}
+                  </p>
+                ))}
+            </div>
+
+            {/* ユーザーメッセージ（右側） */}
+            <div className="absolute w-[306px] top-[531px] left-12 space-y-1 text-right">
+              {conversationData
+                .filter(item => item.speaker === 'user')
+                .slice(-2)
+                .map((item, index) => (
+                  <p
+                    key={index}
+                    className={`text-[#212121] ${item.opacity} text-[23px] leading-[34px] font-bold tracking-[0]`}
+                  >
+                    {item.text}
+                  </p>
+                ))}
+            </div>
+          </>
+        )}
+
+        {/* Recording status text */}
+        {recording && (
+          <div className="absolute top-[656px] left-[170px] font-bold text-[#ec6a52] text-[13px] text-center tracking-[0] leading-normal">
+            録音中...
+          </div>
+        )}
+
+        {/* Processing status text */}
+        {isProcessing && !recording && (
+          <div className="absolute top-[656px] left-1/2 transform -translate-x-1/2 font-bold text-[#ec6a52] text-[13px] text-center tracking-[0] leading-normal">
+            {state === 'transcribing' && '文字起こし中...'}
+            {state === 'thinking' && 'AI が考え中...'}
+          </div>
+        )}
+
+        {/* Microphone button */}
+        <div className="absolute bottom-[72px] left-0 right-0 flex flex-col items-center gap-3">
+          {recording ? (
+            // 録音中: 同心円デザイン
+            <div className="w-[122px] h-[122px] bg-[#ec6a5240] rounded-[61px] flex items-center justify-center">
+              <div className="w-[94px] h-[94px] bg-[#ec6a5280] rounded-[47px] flex items-center justify-center">
+                <Button
+                  onClick={handleToggleRecording}
+                  className="w-[72px] h-[72px] bg-[#ec6a52] rounded-[36px] hover:bg-[#ec6a52]/90 border-none flex items-center justify-center p-0"
+                  size="icon"
+                >
+                  <Mic className="w-8 h-8 text-white" />
+                </Button>
+              </div>
+            </div>
+          ) : (
+            // 非録音時: シンプルなボタン
+            <Button
+              onClick={handleToggleRecording}
+              disabled={isProcessing}
+              className={`w-[72px] h-[72px] rounded-[36px] flex items-center justify-center transition-all hover:scale-105 ${
+                isProcessing 
+                  ? 'bg-gray-400 cursor-not-allowed' 
+                  : 'bg-[#212121] hover:bg-[#333333]'
+              }`}
+              size="icon"
+            >
+              <Mic className="w-8 h-8 text-white" />
+            </Button>
+          )}
+          
+          <span className="font-bold text-[#14142b] text-[13px] text-center tracking-[0] leading-[normal]">
+            {recording ? 'タップで停止' : '長押しで録音'}
+          </span>
+        </div>
+
+        {/* Error display */}
+        {error && (
+          <div className="absolute top-20 left-1/2 transform -translate-x-1/2 z-10 px-4">
+            <div className="bg-red-500 text-white rounded-lg px-4 py-2 shadow-lg max-w-md">
+              <div className="flex items-center justify-between">
+                <span className="text-sm">{error}</span>
+                <button
+                  onClick={() => setError(null)}
+                  className="ml-2 text-white hover:text-red-200"
+                >
+                  ✕
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
Implements issue #36 - AIチャット画面の実装

## Summary
- Add MobileConversationInterface component for mobile devices
- Implement responsive design with mobile-first approach
- Create two UI states: non-recording and recording modes
- Add animated SVG placeholder for AI companion sphere
- Integrate with existing conversation store and hooks

## Technical Changes
- `src/components/MobileConversationInterface.tsx` - New mobile interface
- `public/terase-bot-placeholder.svg` - AI companion placeholder
- `src/app/page.tsx` - Responsive layout switching

Generated with [Claude Code](https://claude.ai/code)