### PR TITLE
refactor: 日記保存ロジックを共通モジュール化

### DIFF
--- a/core/useDiary.ts
+++ b/core/useDiary.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { SupabaseClient as SupabaseClientType } from '@supabase/supabase-js';
 
 // Diary creation input schema
 const diaryInputSchema = z.object({
@@ -20,20 +21,8 @@ const messageInputSchema = z.object({
 
 export type MessageInput = z.infer<typeof messageInputSchema>;
 
-// Supabase client type (compatible with both browser and server)
-type SupabaseClient = {
-  auth: {
-    getUser(): Promise<{ data: { user: { id: string } | null } }>;
-  };
-  from(table: string): {
-    upsert(data: any, options?: any): {
-      select(columns: string): {
-        single(): Promise<{ data: any; error: any }>;
-      };
-    };
-    insert(data: any): Promise<{ error: any }>;
-  };
-};
+// Use the actual Supabase client type
+type SupabaseClient = SupabaseClientType<any, 'public', any>;
 
 /**
  * 共通日記管理関数

--- a/core/useDiary.ts
+++ b/core/useDiary.ts
@@ -1,0 +1,205 @@
+import { z } from 'zod';
+
+// Diary creation input schema
+const diaryInputSchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  text: z.string().min(1),
+  audioPath: z.string().min(1),
+});
+
+export type DiaryInput = z.infer<typeof diaryInputSchema>;
+
+// Message creation input schema
+const messageInputSchema = z.object({
+  diaryId: z.number(),
+  role: z.enum(['user', 'ai']),
+  text: z.string().min(1),
+  audioUrl: z.string().optional(),
+  triggerAI: z.boolean().optional().default(false),
+});
+
+export type MessageInput = z.infer<typeof messageInputSchema>;
+
+// Supabase client type (compatible with both browser and server)
+type SupabaseClient = {
+  auth: {
+    getUser(): Promise<{ data: { user: { id: string } | null } }>;
+  };
+  from(table: string): {
+    upsert(data: any, options?: any): {
+      select(columns: string): {
+        single(): Promise<{ data: any; error: any }>;
+      };
+    };
+    insert(data: any): Promise<{ error: any }>;
+  };
+};
+
+/**
+ * 共通日記管理関数
+ * Web/React Native 両対応の統一インターフェース
+ */
+export class DiaryService {
+  private supabase: SupabaseClient;
+
+  constructor(supabase: SupabaseClient) {
+    this.supabase = supabase;
+  }
+
+  /**
+   * 日記エントリを作成または更新する
+   * @param input 日記入力データ
+   * @returns 作成された日記のID
+   */
+  async createDiary(input: DiaryInput): Promise<number> {
+    // 入力検証
+    const parsed = diaryInputSchema.safeParse(input);
+    if (!parsed.success) {
+      throw new Error(`Invalid input: ${parsed.error.message}`);
+    }
+
+    // ユーザー認証確認
+    const { data: { user } } = await this.supabase.auth.getUser();
+    if (!user) {
+      throw new Error('Unauthorized');
+    }
+
+    // 日記エントリの作成/更新
+    const { data, error } = await this.supabase
+      .from('diaries')
+      .upsert(
+        { user_id: user.id, date: input.date },
+        { onConflict: 'user_id,date', ignoreDuplicates: false }
+      )
+      .select('id')
+      .single();
+
+    if (error || !data) {
+      throw error ?? new Error('Failed to create diary entry');
+    }
+
+    const diaryId = data.id;
+
+    // 初期ユーザーメッセージを作成
+    const { error: messageError } = await this.supabase
+      .from('diary_messages')
+      .insert({
+        diary_id: diaryId,
+        role: 'user',
+        text: input.text,
+        audio_url: input.audioPath,
+      });
+
+    if (messageError) {
+      throw messageError;
+    }
+
+    return diaryId;
+  }
+
+  /**
+   * 既存の日記にメッセージを追加する
+   * @param input メッセージ入力データ
+   * @param options オプション（プラットフォーム固有の機能用）
+   */
+  async addMessageToDiary(input: MessageInput, options?: { useAPI?: boolean }): Promise<void> {
+    // 入力検証
+    const parsed = messageInputSchema.safeParse(input);
+    if (!parsed.success) {
+      throw new Error(`Invalid input: ${parsed.error.message}`);
+    }
+
+    // ユーザー認証確認
+    const { data: { user } } = await this.supabase.auth.getUser();
+    if (!user) {
+      throw new Error('Unauthorized');
+    }
+
+    // WebプラットフォームでtriggerAI機能が必要な場合はAPIを使用
+    if (options?.useAPI && input.triggerAI && typeof window !== 'undefined') {
+      const response = await fetch('/api/diaries/messages', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          diaryId: input.diaryId,
+          role: input.role,
+          text: input.text,
+          audioUrl: input.audioUrl || null,
+          triggerAI: input.triggerAI
+        })
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        throw new Error(`Failed to save message: ${errorBody}`);
+      }
+      return;
+    }
+
+    // 直接データベースに挿入（React Native等）
+    const { error } = await this.supabase
+      .from('diary_messages')
+      .insert({
+        diary_id: input.diaryId,
+        role: input.role,
+        text: input.text,
+        audio_url: input.audioUrl || null,
+      });
+
+    if (error) {
+      throw error;
+    }
+  }
+
+  /**
+   * 今日の日記を確保する（存在しない場合は作成）
+   * @param text 初期テキスト
+   * @param audioPath 音声ファイルパス
+   * @returns 日記ID
+   */
+  async ensureTodayDiary(text: string, audioPath: string): Promise<number> {
+    const today = new Date().toISOString().slice(0, 10);
+    
+    return this.createDiary({
+      date: today,
+      text,
+      audioPath,
+    });
+  }
+}
+
+/**
+ * 統一日記管理フック（React用）
+ * プラットフォーム固有のSupabaseクライアントを受け取る
+ */
+export function useDiary(supabase: SupabaseClient) {
+  const diaryService = new DiaryService(supabase);
+
+  return {
+    createDiary: diaryService.createDiary.bind(diaryService),
+    addMessageToDiary: (input: MessageInput, options?: { useAPI?: boolean }) => 
+      diaryService.addMessageToDiary(input, options),
+    ensureTodayDiary: diaryService.ensureTodayDiary.bind(diaryService),
+  };
+}
+
+/**
+ * レガシー互換性のための型定義とユーティリティ
+ */
+export { diaryInputSchema, messageInputSchema };
+
+// FormData からの DiaryInput 変換ユーティリティ
+export function parseDiaryFromFormData(formData: FormData): DiaryInput {
+  return diaryInputSchema.parse({
+    date: formData.get('date'),
+    text: formData.get('text'),
+    audioPath: formData.get('audioPath'),
+  });
+}
+
+// JSON からの MessageInput 変換ユーティリティ
+export function parseMessageFromJSON(json: any): MessageInput {
+  return messageInputSchema.parse(json);
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      '@core': path.resolve(__dirname, 'core'),
+    };
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/src/app/actions/saveDiary.ts
+++ b/src/app/actions/saveDiary.ts
@@ -1,52 +1,18 @@
 'use server';
 
-import { z } from 'zod';
 import { supabaseServer } from '@/lib/supabase/server';
-
-const diarySchema = z.object({
-  date:      z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
-  text:      z.string().min(1),
-  audioPath: z.string().min(1),
-});
-type DiaryInput = z.infer<typeof diarySchema>;
+import { DiaryService, parseDiaryFromFormData } from '@core/useDiary';
 
 export async function saveDiary(
   _prev: unknown,
   fd: FormData,
 ): Promise<number> {
-  const parsed = diarySchema.safeParse({
-    date:      fd.get('date'),
-    text:      fd.get('text'),
-    audioPath: fd.get('audioPath'),
-  });
-  if (!parsed.success) throw new Error(parsed.error.message);
-  const input: DiaryInput = parsed.data;
+  // Parse FormData using shared utility
+  const input = parseDiaryFromFormData(fd);
 
+  // Use shared diary service
   const supabase = await supabaseServer();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) throw new Error('Unauthorized');
-
-  const { data, error } = await supabase
-    .from('diaries')
-    .upsert(
-      { user_id: user.id, date: input.date },
-      { onConflict: 'user_id,date', ignoreDuplicates: false }
-    )
-    .select('id')
-    .single();
-  if (error || !data) throw error ?? new Error('insert failed');
-
-  const diaryId = data.id;
-
-  const { error: mErr } = await supabase
-    .from('diary_messages')
-    .insert({
-      diary_id:  diaryId,
-      role:      'user',
-      text:      input.text,
-      audio_url: input.audioPath,
-    });
-  if (mErr) throw mErr;
-
-  return diaryId;
+  const diaryService = new DiaryService(supabase);
+  
+  return diaryService.createDiary(input);
 }

--- a/src/components/hooks/useConversation.ts
+++ b/src/components/hooks/useConversation.ts
@@ -20,7 +20,7 @@ export function useConversation(diaryId?: number) {
   const { setSpeaking } = useAudioStore();
   
   // Use shared diary service
-  const supabase = supabaseBrowser();
+  const supabase = supabaseBrowser;
   const { addMessageToDiary, ensureTodayDiary } = useDiary(supabase);
 
   // Save message to diary_messages table

--- a/src/components/hooks/useConversation.ts
+++ b/src/components/hooks/useConversation.ts
@@ -21,7 +21,7 @@ export function useConversation(diaryId?: number) {
   
   // Use shared diary service
   const supabase = supabaseBrowser();
-  const { createDiary, addMessageToDiary, ensureTodayDiary } = useDiary(supabase);
+  const { addMessageToDiary, ensureTodayDiary } = useDiary(supabase);
 
   // Save message to diary_messages table
   const saveMessageToDiary = useCallback(async (diaryId: number, role: 'user' | 'ai', text: string, audioUrl?: string, triggerAI = false) => {

--- a/src/test/diary-messages.test.ts
+++ b/src/test/diary-messages.test.ts
@@ -8,12 +8,12 @@ type MockSupabaseClient = {
     getUser(): Promise<{ data: { user: { id: string } | null } }>;
   };
   from(table: string): {
-    upsert(data: any, options?: any): {
+    upsert(data: Record<string, unknown>, options?: Record<string, unknown>): {
       select(columns: string): {
-        single(): Promise<{ data: any; error: any }>;
+        single(): Promise<{ data: Record<string, unknown>; error: unknown }>;
       };
     };
-    insert(data: any): Promise<{ error: any }>;
+    insert(data: Record<string, unknown>): Promise<{ error: unknown }>;
   };
 };
 

--- a/src/test/diary-messages.test.ts
+++ b/src/test/diary-messages.test.ts
@@ -2,6 +2,21 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { supabaseBrowser } from '@/lib/supabase/browser'
 import { DiaryService } from '@core/useDiary'
 
+// Mock Supabase client type for testing
+type MockSupabaseClient = {
+  auth: {
+    getUser(): Promise<{ data: { user: { id: string } | null } }>;
+  };
+  from(table: string): {
+    upsert(data: any, options?: any): {
+      select(columns: string): {
+        single(): Promise<{ data: any; error: any }>;
+      };
+    };
+    insert(data: any): Promise<{ error: any }>;
+  };
+};
+
 // Test data
 const mockDiaryId = 123
 const mockUserId = 'test-user-id'
@@ -42,7 +57,7 @@ describe('Diary Messages Integration', () => {
         })
       }
 
-      const diaryService = new DiaryService(mockSupabase as any)
+      const diaryService = new DiaryService(mockSupabase as MockSupabaseClient)
       
       const result = await diaryService.createDiary({
         date: '2025-05-24',
@@ -75,7 +90,7 @@ describe('Diary Messages Integration', () => {
         from: vi.fn().mockReturnValue({ insert: mockInsert })
       }
 
-      const diaryService = new DiaryService(mockSupabase as any)
+      const diaryService = new DiaryService(mockSupabase as MockSupabaseClient)
       
       await diaryService.addMessageToDiary({
         diaryId: mockDiaryId,


### PR DESCRIPTION
## 概要

日記の保存ロジックを `/core/useDiary.ts` に集約し、状態管理と保存処理を再整理しました。

## 変更内容

- 新規作成: `core/useDiary.ts` で統一日記管理機能を実装
- 既存コードを共通モジュールを使用するようにリファクタリング
- テストを更新しウルト体テストを追加

## AC 確認

- ✅ createDiary() 関数が共通モジュールに
- ✅ Webで問題なく保存できる
- ✅ テストが通る

Closes #74

Generated with [Claude Code](https://claude.ai/code)